### PR TITLE
Fix regression in parsing large inputs on RHEL 9.4, SMHI fix segfault regex

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,13 @@ INCLUDE(CMakePackageConfigHelpers)
 INCLUDE(GNUInstallDirs)
 SET(CMAKE_CXX_STANDARD 11)
 
+# Enable all warnings
+IF(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  ADD_COMPILE_OPTIONS(-Wall -Wextra -Wpedantic -Wconversion -Wformat -Wformat=2 -Wformat-security -Werror=format-security)
+ELSEIF(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  ADD_COMPILE_OPTIONS(/W4 /WX)
+ENDIF()
+
 SET(MI_PROGRAMOPTIONS_HEADERS
   mi_programoptions.h
   mi_programoptions_version.h

--- a/mi_programoptions.h
+++ b/mi_programoptions.h
@@ -164,7 +164,7 @@ private:
   string_v::const_iterator pbegin_;
 };
 
-value_set parse_config_file(const std::string& filename, option_set& options) ;
+value_set parse_config_file(const std::string& filename, option_set& options);
 value_set parse_config_file(std::istream& infile, option_set& options);
 
 value_set parse_command_line(const std::vector<std::string>& argv, option_set& options, std::vector<std::string>& positional);

--- a/mi_programoptions.h
+++ b/mi_programoptions.h
@@ -30,6 +30,8 @@
 #ifndef MI_PROGRAMOPTIONS_H
 #define MI_PROGRAMOPTIONS_H
 
+//#define USE_REGEX_FOR_PARSE_COMMAND_LINE
+
 #include <iosfwd>
 #include <map>
 #include <regex>
@@ -162,7 +164,7 @@ private:
   string_v::const_iterator pbegin_;
 };
 
-value_set parse_config_file(const std::string& filename, option_set& options);
+value_set parse_config_file(const std::string& filename, option_set& options) ;
 value_set parse_config_file(std::istream& infile, option_set& options);
 
 value_set parse_command_line(const std::vector<std::string>& argv, option_set& options, std::vector<std::string>& positional);


### PR DESCRIPTION
On RHEL 9.4, we encountered a regression, SIGSEGV, in the mi-programoptions library when handling large command-line inputs (around 27,000 characters or more). 
This issue arose after upgrading to the newer OS version.

## Environment

* **OS**: RHEL 9.4
* **glibc version**: 2.34 (`glibc-2.34-100.el9_4.2.x86_64`)
* **libstdc++ version**: 11.4.1 (`libstdc++-11.4.1-3.el9.x86_64`)
* **libgcc version**: 11.4.1 (`libgcc-11.4.1-3.el9.x86_64`)
* C++11 is used. I have tried with the later versions available in GCC as well, but the same result occurs.

## Problem
For inputs exceeding 27,000 characters, the library fails to parse command-line options and results in a segmentation fault. This issue appears specific to RHEL 9.4 and tests have been added to cover larger input scenarios.

The issue likely stems from the use of `std::regex`, which in this case appears to operate as a **Nondeterministic Finite Automaton (NFA)**. 
The large input size leads to excessive backtracking, producing a 50k+ backtrace and eventually causing a segmentation fault due to stack exhaustion.

## Solution
A non-regex-based command-line parsing function was implemented to replace the existing regex-based parser for large inputs. 
This resolves the issue by avoiding the costly backtracking and internal data structures that `std::regex` produces when processing large inputs.